### PR TITLE
4 feat apply middleware for role based access control

### DIFF
--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @param  string   $roles  Comma-separated list (e.g. "admin,seller")
+     * @return Response
+     */
+    public function handle(Request $request, Closure $next, string $roles): Response
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        $allowed = explode(',', $roles);
+
+        if (! in_array($user->role, $allowed, true)) {
+            return response()->json(['message' => 'Forbidden.'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,14 +1,15 @@
 <?php
 
+use App\Http\Middleware\CheckRole;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
-        api: __DIR__.'/../routes/api.php',
-        commands: __DIR__.'/../routes/console.php',
+        web: __DIR__ . '/../routes/web.php',
+        api: __DIR__ . '/../routes/api.php',
+        commands: __DIR__ . '/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
@@ -17,7 +18,9 @@ return Application::configure(basePath: dirname(__DIR__))
             \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
         ]);
 
-        //
+        $middleware->alias([
+            'role' => CheckRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,8 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'role' => 'customer', // default role (boleh kamu ubah ke random kalau mau)
+
         ];
     }
 
@@ -37,7 +39,7 @@ class UserFactory extends Factory
      */
     public function unverified(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn(array $attributes) => [
             'email_verified_at' => null,
         ]);
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,18 +15,6 @@ services:
     depends_on:
       - db
 
-  vite:
-    image: node:18
-    working_dir: /var/www
-    volumes:
-      - ./:/var/www
-    ports:
-      - "5173:5173"
-    command: sh -c "npm install -g pnpm && pnpm install && pnpm run dev"
-    networks:
-      - laravel
-    depends_on:
-      - app
 
   nginx:
     image: nginx:latest

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,4 +13,20 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);
 });
 
+Route::middleware(['auth:sanctum', 'role:admin'])
+    ->prefix('admin')
+    ->group(function () {
+        Route::get('/dashboard', fn () => response()->json(['message' => 'You are an admin']));
+    });
 
+Route::middleware(['auth:sanctum', 'role:seller'])
+    ->prefix('seller')
+    ->group(function () {
+        Route::get('/dashboard', fn () => response()->json(['message' => 'You are a seller']));
+    });
+
+Route::middleware(['auth:sanctum', 'role:customer'])
+    ->prefix('customer')
+    ->group(function () {
+        Route::get('/dashboard', fn () => response()->json(['message' => 'You are a customer']));
+    });

--- a/tests/Feature/RoleAccessTest.php
+++ b/tests/Feature/RoleAccessTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class RoleAccessTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     */
+
+    use RefreshDatabase;
+
+    /** @test */
+    public function admin_can_access_admin_endpoint_only()
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/admin/dashboard')->assertOk();
+        $this->getJson('/api/seller/dashboard')->assertForbidden();
+        $this->getJson('/api/customer/dashboard')->assertForbidden();
+    }
+
+
+    /** @test */
+    public function seller_can_access_seller_endpoint_only()
+    {
+        $user = User::factory()->create(['role' => 'seller']);
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/seller/dashboard')->assertOk();
+        $this->getJson('/api/admin/dashboard')->assertForbidden();
+        $this->getJson('/api/customer/dashboard')->assertForbidden();
+    }
+
+
+    /** @test */
+    public function customer_can_access_customer_endpoint_only()
+    {
+        $user = User::factory()->create(['role' => 'customer']);
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/customer/dashboard')->assertOk();
+        $this->getJson('/api/admin/dashboard')->assertForbidden();
+        $this->getJson('/api/seller/dashboard')->assertForbidden();
+    }
+}


### PR DESCRIPTION
This pull request introduces role-based access control (RBAC) to the application by implementing a middleware for role checking, updating user roles, and defining role-specific API routes. Additionally, it removes the `vite` service from the Docker setup and adds comprehensive tests to validate role-based access functionality.

### Role-based Access Control (RBAC):

* [`app/Http/Middleware/CheckRole.php`](diffhunk://#diff-a1c097ddb8c48745a21bd420aeaa8d5e755e9cd485117d3b987ab82ca4cb85d9R1-R35): Added a new `CheckRole` middleware to enforce role-based access control. It checks if the authenticated user's role matches the allowed roles for a given route.
* [`bootstrap/app.php`](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518R3): Registered the `CheckRole` middleware with an alias `role` for easy application in routes. [[1]](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518R3) [[2]](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518L20-R23)

### API Route Updates:

* [`routes/api.php`](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR16-R32): Defined role-specific API routes under `admin`, `seller`, and `customer` prefixes, protected by both authentication and role-based middleware. Each route returns a simple JSON response confirming access.

### User Role Management:

* [`database/factories/UserFactory.php`](diffhunk://#diff-0db00302e9c3c5ad4fd47629fe517d343a414c5667b897b5ae2caa6dc2e37692R32-R33): Added a default `role` field (`customer`) to the user factory for consistent user role assignment during testing and seeding.

### Testing Role-based Access:

* [`tests/Feature/RoleAccessTest.php`](diffhunk://#diff-7aabe2ab02f23aba719e326eb35bac3c54438f12a8dabddf31f856ac1ab71b0cR1-R53): Created feature tests to ensure that users with specific roles can access their respective endpoints while being denied access to others. Tests cover `admin`, `seller`, and `customer` roles.

### Docker Setup Simplification:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L18-L29): Removed the `vite` service from the Docker setup, simplifying the configuration. # #4 